### PR TITLE
将 “你只能通过值调用 Read” 改为 “你通过值只能调用 Read”

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ func (s *S) Write(str string) {
 
 sVals := map[int]S{1: {"A"}}
 
-// 你只能通过值调用 Read
+// 你通过值只能调用 Read
 sVals[1].Read()
 
 // 这不能编译通过：


### PR DESCRIPTION
调整“通过值”与“只能”的顺序，更易理解